### PR TITLE
Added timezone property

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,8 +9,15 @@
     <app inline-template>
         <div>
             <div>Selected session: <code>{{ session }}</code></div>
+            <select v-model="timezone">
+                <option value="Pacific/Tahiti">Pacific/Tahiti</option>
+                <option value="Europe/Kiev">Europe/Kiev</option>
+                <option value="Europe/Minsk">Europe/Minsk</option>
+                <option value="America/Phoenix">America/Phoenix</option>
+            </select>
             <service-session-selector :service="service"
                                       v-model="session"
+                                      :timezone="timezone"
             ></service-session-selector>
         </div>
     </app>
@@ -53,6 +60,7 @@
                 <session-picker v-model="session"
                                 :selected-day.sync="selectedDay"
                                 :service="service"
+                                :timezone="timezone"
                                 :sessions="selectedDaySessions"
                                 :prev-available-day="prevAvailableDay"
                                 :next-available-day="nextAvailableDay"
@@ -119,12 +127,13 @@
         datepicker: 'https://cdn.jsdelivr.net/npm/vuejs-datepicker@0.9.26/dist/build.min',
         lodash: 'https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.4/lodash.min',
         moment: 'https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.20.1/moment.min',
+        'moment-timezone': 'https://cdnjs.cloudflare.com/ajax/libs/moment-timezone/0.5.17/moment-timezone-with-data-2012-2022.min',
         momentRange: 'https://cdnjs.cloudflare.com/ajax/libs/moment-range/4.0.1/moment-range',
       }
     })
 
     var dependenciesList = ['bookingWizardComponents','uiFramework', 'bottle', 'vue', 'axios', 'humanizeDuration', 'cjs!datepicker',
-      'moment', 'lodash', 'cjs!momentRange', 'stdLib']
+      'moment', 'moment-timezone', 'lodash', 'cjs!momentRange', 'stdLib']
 
     function defineServices (di, dependencies) {
       di.factory('vue', function () {
@@ -138,8 +147,9 @@
           inject: ['service-session-selector'],
           data: function () {
             return {
-              service: {"id":29,"name":"simple","bookingsEnabled":"1","sessionLengths":[{"sessionLength":3600,"price":{"amount":"35","currency":"USD","formatted":"$35.00"}}],"displayOptions":{"useCustomerTimezone":false},"timezone":"UTC+0","availabilities":{"rules":[]}},
-              session: null
+              service: {"id":34,"name":"Yoga Crash","description":"","imageSrc":false,"bookingsEnabled":"1","sessionLengths":[{"sessionLength":2700,"price":{"amount":"100","currency":"USD","formatted":"$100.00"}},{"sessionLength":5400,"price":{"amount":"200","currency":"USD","formatted":"$200.00"}}],"displayOptions":{"useCustomerTimezone":false},"timezone":"UTC+0","availabilities":{"rules":[]}},
+              session: null,
+              timezone: null
             }
           },
           components: {
@@ -166,7 +176,7 @@
       })
 
       di.factory('moment', function (container) {
-        var moment = dependencies.moment
+        var moment = dependencies['moment-timezone']
         return dependencies.momentRange.extendMoment(moment)
         return moment
       })

--- a/index.html
+++ b/index.html
@@ -181,13 +181,17 @@
         return moment
       })
 
+      di.factory('CreateDatetimeCapable', function (container) {
+        return dependencies.bookingWizardComponents.MfCreateDatetimeCapable(container.moment)
+      })
+
       di.factory('service-session-selector', function (container) {
         console.info(dependencies)
-        return dependencies.bookingWizardComponents.CfServiceSessionSelector(container.moment, container.sessionApi, container.config.datetime)
+        return dependencies.bookingWizardComponents.CfServiceSessionSelector(container.CreateDatetimeCapable, container.sessionApi, container.config.datetime)
       })
 
       di.factory('session-picker', function (container) {
-        return dependencies.bookingWizardComponents.CfSessionPicker(container.moment, container.config.datetime)
+        return dependencies.bookingWizardComponents.CfSessionPicker(container.CreateDatetimeCapable, container.config.datetime)
       })
 
       di.factory('sessionApi', function (container) {

--- a/index.html
+++ b/index.html
@@ -144,12 +144,12 @@
 
       di.factory('app', function () {
         return {
-          inject: ['service-session-selector'],
+          inject: ['service-session-selector', 'moment'],
           data: function () {
             return {
               service: {"id":34,"name":"Yoga Crash","description":"","imageSrc":false,"bookingsEnabled":"1","sessionLengths":[{"sessionLength":2700,"price":{"amount":"100","currency":"USD","formatted":"$100.00"}},{"sessionLength":5400,"price":{"amount":"200","currency":"USD","formatted":"$200.00"}}],"displayOptions":{"useCustomerTimezone":false},"timezone":"UTC+0","availabilities":{"rules":[]}},
               session: null,
-              timezone: null
+              timezone: this.moment.tz.guess()
             }
           },
           components: {

--- a/src/components/CfServiceSessionSelector.js
+++ b/src/components/CfServiceSessionSelector.js
@@ -53,10 +53,7 @@ export default function CfServiceSessionSelector (moment, sessionsApi, dateForma
         from: 'createDatetime',
         default () {
           return (value, timezone) => {
-            if (!timezone) {
-              timezone = 'UTC'
-            }
-            return moment.tz(value, timezone)
+            return moment.tz(value, timezone || 'UTC')
           }
         }
       }

--- a/src/components/CfServiceSessionSelector.js
+++ b/src/components/CfServiceSessionSelector.js
@@ -47,7 +47,7 @@ export default function CfServiceSessionSelector (moment, sessionsApi, dateForma
        *
        * @since [*next-version*]
        *
-       * @property {Function} createDatetime
+       * @property {CreateDatetimeFunction} createDatetime
        */
       createDatetime: {
         from: 'createDatetime',

--- a/src/components/CfServiceSessionSelector.js
+++ b/src/components/CfServiceSessionSelector.js
@@ -47,14 +47,14 @@ export default function CfServiceSessionSelector (moment, sessionsApi, dateForma
        *
        * @since [*next-version*]
        *
-       * @property {Function} momentInTimezone
+       * @property {Function} createDatetime
        */
-      createMomentInTimezone: {
-        from: 'momentInTimezone',
+      createDatetime: {
+        from: 'createDatetime',
         default () {
-          return (value, timezone = null) => {
+          return (value, timezone) => {
             if (!timezone) {
-              return moment(value)
+              timezone = 'UTC'
             }
             return moment.tz(value, timezone)
           }
@@ -249,7 +249,7 @@ export default function CfServiceSessionSelector (moment, sessionsApi, dateForma
         if (availableDaysCount - 1 === selectedDayIndex) {
           return null
         }
-        return this.momentInTimezone(this.availableDays[selectedDayIndex + 1]).format()
+        return this.createLocalDatetime(this.availableDays[selectedDayIndex + 1]).format()
       },
 
       /**
@@ -264,7 +264,7 @@ export default function CfServiceSessionSelector (moment, sessionsApi, dateForma
         if (selectedDayIndex === 0) {
           return null
         }
-        return this.momentInTimezone(this.availableDays[selectedDayIndex - 1]).format()
+        return this.createLocalDatetime(this.availableDays[selectedDayIndex - 1]).format()
       },
 
       /**
@@ -286,7 +286,7 @@ export default function CfServiceSessionSelector (moment, sessionsApi, dateForma
        * @property {Date}
        */
       currentDay () {
-        return this.momentInTimezone().startOf('day').toDate()
+        return this.createLocalDatetime().startOf('day').toDate()
       },
 
       /**
@@ -298,7 +298,7 @@ export default function CfServiceSessionSelector (moment, sessionsApi, dateForma
         if (!this.value) {
           return null
         }
-        const sessionStart = this.momentInTimezone(this.value.start)
+        const sessionStart = this.createLocalDatetime(this.value.start)
         return sessionStart.format(dateFormats.sessionTime) + ', ' + sessionStart.format(dateFormats.dayFull)
       }
     },
@@ -324,10 +324,10 @@ export default function CfServiceSessionSelector (moment, sessionsApi, dateForma
       editSession () {
         this.preloadedSession = this.sessionReadTransformer.transform(this.value)
 
-        const sessionStart = this.momentInTimezone(this.preloadedSession.start)
+        const sessionStart = this.createLocalDatetime(this.preloadedSession.start)
 
-        this.selectedDay = this.momentInTimezone(sessionStart).startOf('day').format()
-        this.selectedMonth = this.momentInTimezone(sessionStart).startOf('month').format()
+        this.selectedDay = this.createLocalDatetime(sessionStart).startOf('day').format()
+        this.selectedMonth = this.createLocalDatetime(sessionStart).startOf('month').format()
 
         this.loadSessions().then(() => {
           this.isEditing = false
@@ -403,7 +403,7 @@ export default function CfServiceSessionSelector (moment, sessionsApi, dateForma
       _setCleanStateValues () {
         this.selectedDay = null
 
-        this.selectedMonth = this.momentInTimezone().toDate()
+        this.selectedMonth = this.createLocalDatetime().toDate()
         this.sessions = []
 
         this.$nextTick(() => {
@@ -439,7 +439,7 @@ export default function CfServiceSessionSelector (moment, sessionsApi, dateForma
        * @return {{service: Number, start: (string), end: (string)}}
        */
       _prepareSessionRequestParams () {
-        const currentDay = this.momentInTimezone()
+        const currentDay = this.createLocalDatetime()
         const firstDayOfMonth = moment(this.selectedMonth).startOf('month')
         const lastDayOfMonth = moment(this.selectedMonth).endOf('month')
 
@@ -454,17 +454,17 @@ export default function CfServiceSessionSelector (moment, sessionsApi, dateForma
       },
 
       /**
-       * Create moment object in timezone.
+       * Create moment object in local timezone.
        *
        * @param {moment|string|Date} value Datetime value that can be accepted by moment.
        *
        * @return {moment}
        */
-      momentInTimezone (value = null) {
+      createLocalDatetime (value = null) {
         if (!value) {
           value = moment()
         }
-        return this.createMomentInTimezone(value, this.timezone)
+        return this.createDatetime(value, this.timezone)
       },
 
       /**
@@ -477,7 +477,7 @@ export default function CfServiceSessionSelector (moment, sessionsApi, dateForma
        * @return {string} Day key.
        */
       _getDayKey (value) {
-        return this.momentInTimezone(value).format(dateFormats.dayKey)
+        return this.createLocalDatetime(value).format(dateFormats.dayKey)
       }
     },
     components: {

--- a/src/components/CfServiceSessionSelector.js
+++ b/src/components/CfServiceSessionSelector.js
@@ -6,7 +6,7 @@
  *
  * @since [*next-version*]
  *
- * @param {moment} moment MomentJS.
+ * @param {CreateDatetimeCapable} CreateDatetimeCapable Mixin that provides ability to work with datetime.
  * @param {object} sessionsApi Session API wrapper, used for querying sessions.
  * @param {{
  *  dayKey: (string), // How to format day as a key,
@@ -16,9 +16,11 @@
  *
  * @return {object}
  */
-export default function CfServiceSessionSelector (moment, sessionsApi, dateFormats) {
+export default function CfServiceSessionSelector (CreateDatetimeCapable, sessionsApi, dateFormats) {
   return {
     template: '#service-session-selector-template',
+
+    mixins: [ CreateDatetimeCapable ],
 
     inject: {
       /**
@@ -40,23 +42,7 @@ export default function CfServiceSessionSelector (moment, sessionsApi, dateForma
        *
        * @since [*next-version*]
        */
-      'sessionReadTransformer': 'sessionReadTransformer',
-
-      /**
-       * Function for creating moment instance in given timezone.
-       *
-       * @since [*next-version*]
-       *
-       * @property {CreateDatetimeFunction} createDatetime
-       */
-      createDatetime: {
-        from: 'createDatetime',
-        default () {
-          return (value, timezone) => {
-            return moment.tz(value, timezone || 'UTC')
-          }
-        }
-      }
+      'sessionReadTransformer': 'sessionReadTransformer'
     },
     data () {
       return {
@@ -437,8 +423,8 @@ export default function CfServiceSessionSelector (moment, sessionsApi, dateForma
        */
       _prepareSessionRequestParams () {
         const currentDay = this.createLocalDatetime()
-        const firstDayOfMonth = moment(this.selectedMonth).startOf('month')
-        const lastDayOfMonth = moment(this.selectedMonth).endOf('month')
+        const firstDayOfMonth = this.createLocalDatetime(this.selectedMonth).startOf('month')
+        const lastDayOfMonth = this.createLocalDatetime(this.selectedMonth).endOf('month')
 
         const start = (currentDay.isAfter(firstDayOfMonth) ? currentDay : firstDayOfMonth).startOf('day').format()
         const end = lastDayOfMonth.endOf('day').format()
@@ -448,20 +434,6 @@ export default function CfServiceSessionSelector (moment, sessionsApi, dateForma
           start,
           end
         }
-      },
-
-      /**
-       * Create moment object in local timezone.
-       *
-       * @param {moment|string|Date} value Datetime value that can be accepted by moment.
-       *
-       * @return {moment}
-       */
-      createLocalDatetime (value = null) {
-        if (!value) {
-          value = moment()
-        }
-        return this.createDatetime(value, this.timezone)
       },
 
       /**

--- a/src/components/CfSessionPicker.js
+++ b/src/components/CfSessionPicker.js
@@ -3,7 +3,7 @@
  *
  * @since [*next-version*]
  *
- * @param {moment} moment MomentJS.
+ * @param {CreateDatetimeCapable} CreateDatetimeCapable Mixin that provides ability to work with datetime.
  * @param {{
  *  sessionTime: (string), // How to format session time,
  *  dayFull: (string), // How to format day for day heading,
@@ -12,9 +12,11 @@
  *
  * @return {object}
  */
-export default function CfSessionPicker (moment, dateFormats) {
+export default function CfSessionPicker (CreateDatetimeCapable, dateFormats) {
   return {
     template: '#session-picker-template',
+
+    mixins: [ CreateDatetimeCapable ],
 
     inject: {
       /**
@@ -22,23 +24,7 @@ export default function CfSessionPicker (moment, dateFormats) {
        *
        * @since [*next-version*]
        */
-      'humanizeDuration': 'humanizeDuration',
-
-      /**
-       * Function for creating moment instance in given timezone.
-       *
-       * @since [*next-version*]
-       *
-       * @property {CreateDatetimeFunction} createDatetime
-       */
-      createDatetime: {
-        from: 'createDatetime',
-        default () {
-          return (value, timezone) => {
-            return moment.tz(value, timezone || 'UTC')
-          }
-        }
-      }
+      'humanizeDuration': 'humanizeDuration'
     },
 
     data () {
@@ -224,20 +210,6 @@ export default function CfSessionPicker (moment, dateFormats) {
           && this.value.start === session.start
           && this.value.end === session.end
           && this.value.resource === session.resource
-      },
-
-      /**
-       * Create moment object in local timezone.
-       *
-       * @param {moment|string|Date} value Datetime value that can be accepted by moment.
-       *
-       * @return {moment}
-       */
-      createLocalDatetime (value = null) {
-        if (!value) {
-          value = moment()
-        }
-        return this.createDatetime(value, this.timezone)
       },
 
       /**

--- a/src/components/CfSessionPicker.js
+++ b/src/components/CfSessionPicker.js
@@ -29,7 +29,7 @@ export default function CfSessionPicker (moment, dateFormats) {
        *
        * @since [*next-version*]
        *
-       * @property {Function} createDatetime
+       * @property {CreateDatetimeFunction} createDatetime
        */
       createDatetime: {
         from: 'createDatetime',

--- a/src/components/CfSessionPicker.js
+++ b/src/components/CfSessionPicker.js
@@ -35,10 +35,7 @@ export default function CfSessionPicker (moment, dateFormats) {
         from: 'createDatetime',
         default () {
           return (value, timezone) => {
-            if (!timezone) {
-              timezone = 'UTC'
-            }
-            return moment.tz(value, timezone)
+            return moment.tz(value, timezone || 'UTC')
           }
         }
       }

--- a/src/components/CfSessionPicker.js
+++ b/src/components/CfSessionPicker.js
@@ -29,14 +29,14 @@ export default function CfSessionPicker (moment, dateFormats) {
        *
        * @since [*next-version*]
        *
-       * @property {Function} momentInTimezone
+       * @property {Function} createDatetime
        */
-      createMomentInTimezone: {
-        from: 'momentInTimezone',
+      createDatetime: {
+        from: 'createDatetime',
         default () {
-          return (value, timezone = null) => {
+          return (value, timezone) => {
             if (!timezone) {
-              return moment(value)
+              timezone = 'UTC'
             }
             return moment.tz(value, timezone)
           }
@@ -168,7 +168,7 @@ export default function CfSessionPicker (moment, dateFormats) {
        * @property {string}
        */
       selectedDayLabel () {
-        return this.momentInTimezone(this.selectedDay).format(dateFormats.dayFull)
+        return this.createLocalDatetime(this.selectedDay).format(dateFormats.dayFull)
       },
 
       /**
@@ -179,7 +179,7 @@ export default function CfSessionPicker (moment, dateFormats) {
        * @property {string}
        */
       selectedDaySessionsLabel () {
-        return this.momentInTimezone(this.selectedDay).format(dateFormats.dayShort)
+        return this.createLocalDatetime(this.selectedDay).format(dateFormats.dayShort)
       },
     },
 
@@ -210,7 +210,7 @@ export default function CfSessionPicker (moment, dateFormats) {
        * @return {*}
        */
       sessionLabel (session) {
-        return this.momentInTimezone(session.start).format(dateFormats.sessionTime)
+        return this.createLocalDatetime(session.start).format(dateFormats.sessionTime)
       },
 
       /**
@@ -230,17 +230,17 @@ export default function CfSessionPicker (moment, dateFormats) {
       },
 
       /**
-       * Create moment object in timezone.
+       * Create moment object in local timezone.
        *
        * @param {moment|string|Date} value Datetime value that can be accepted by moment.
        *
        * @return {moment}
        */
-      momentInTimezone (value = null) {
+      createLocalDatetime (value = null) {
         if (!value) {
           value = moment()
         }
-        return this.createMomentInTimezone(value, this.timezone)
+        return this.createDatetime(value, this.timezone)
       },
 
       /**

--- a/src/components/CfSessionPicker.js
+++ b/src/components/CfSessionPicker.js
@@ -16,14 +16,33 @@ export default function CfSessionPicker (moment, dateFormats) {
   return {
     template: '#session-picker-template',
 
-    inject: [
+    inject: {
       /**
        * Function for transforming duration in seconds to human readable format.
        *
        * @since [*next-version*]
        */
-      'humanizeDuration',
-    ],
+      'humanizeDuration': 'humanizeDuration',
+
+      /**
+       * Function for creating moment instance in given timezone.
+       *
+       * @since [*next-version*]
+       *
+       * @property {Function} momentInTimezone
+       */
+      createMomentInTimezone: {
+        from: 'momentInTimezone',
+        default () {
+          return (value, timezone = null) => {
+            if (!timezone) {
+              return moment(value)
+            }
+            return moment.tz(value, timezone)
+          }
+        }
+      }
+    },
 
     data () {
       return {
@@ -71,6 +90,15 @@ export default function CfSessionPicker (moment, dateFormats) {
         default () {
           return []
         }
+      },
+
+      /**
+       * @since [*next-version*]
+       *
+       * @property {string|null} timezone Name of timezone in which sessions will be displayed.
+       */
+      timezone: {
+        default: null
       },
 
       /**
@@ -140,7 +168,7 @@ export default function CfSessionPicker (moment, dateFormats) {
        * @property {string}
        */
       selectedDayLabel () {
-        return moment(this.selectedDay).format(dateFormats.dayFull)
+        return this.momentInTimezone(this.selectedDay).format(dateFormats.dayFull)
       },
 
       /**
@@ -151,7 +179,7 @@ export default function CfSessionPicker (moment, dateFormats) {
        * @property {string}
        */
       selectedDaySessionsLabel () {
-        return moment(this.selectedDay).format(dateFormats.dayShort)
+        return this.momentInTimezone(this.selectedDay).format(dateFormats.dayShort)
       },
     },
 
@@ -182,7 +210,7 @@ export default function CfSessionPicker (moment, dateFormats) {
        * @return {*}
        */
       sessionLabel (session) {
-        return moment(session.start).format(dateFormats.sessionTime)
+        return this.momentInTimezone(session.start).format(dateFormats.sessionTime)
       },
 
       /**
@@ -199,6 +227,20 @@ export default function CfSessionPicker (moment, dateFormats) {
           && this.value.start === session.start
           && this.value.end === session.end
           && this.value.resource === session.resource
+      },
+
+      /**
+       * Create moment object in timezone.
+       *
+       * @param {moment|string|Date} value Datetime value that can be accepted by moment.
+       *
+       * @return {moment}
+       */
+      momentInTimezone (value = null) {
+        if (!value) {
+          value = moment()
+        }
+        return this.createMomentInTimezone(value, this.timezone)
       },
 
       /**

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import SessionApi from './api/SessionApi'
 import CfServiceSessionSelector from './components/CfServiceSessionSelector'
 import CfSessionPicker from './components/CfSessionPicker'
 import SessionReadTransformer from './transformer/SessionReadTransformer'
+import MfCreateDatetimeCapable from './mixins/MfCreateDatetimeCapable'
 
 export {
   SessionApi,
@@ -10,4 +11,5 @@ export {
   SessionReadTransformer,
   CfServiceSessionSelector,
   CfSessionPicker,
+  MfCreateDatetimeCapable
 }

--- a/src/mixins/MfCreateDatetimeCapable.js
+++ b/src/mixins/MfCreateDatetimeCapable.js
@@ -1,0 +1,45 @@
+/**
+ * Create mixin that provides functionality to create datetimes.
+ *
+ * @since [*next-version*]
+ *
+ * @param {moment} moment Moment JS.
+ *
+ * @return {CreateDatetimeCapable}
+ */
+export default function MfCreateDatetimeCapable (moment) {
+  return {
+    inject: {
+      /**
+       * Function for creating moment instance in given timezone.
+       *
+       * @since [*next-version*]
+       *
+       * @property {CreateDatetimeFunction} createDatetime
+       */
+      createDatetime: {
+        from: 'createDatetime',
+        default () {
+          return (value, timezone) => {
+            return moment.tz(value, timezone || 'UTC')
+          }
+        }
+      }
+    },
+    methods: {
+      /**
+       * Create moment object in local timezone.
+       *
+       * @param {moment|string|Date} value Datetime value that can be accepted by moment.
+       *
+       * @return {moment}
+       */
+      createLocalDatetime (value = null) {
+        if (!value) {
+          value = moment()
+        }
+        return this.createDatetime(value, this.timezone)
+      },
+    }
+  }
+}

--- a/src/mixins/MfCreateDatetimeCapable.js
+++ b/src/mixins/MfCreateDatetimeCapable.js
@@ -24,21 +24,24 @@ export default function MfCreateDatetimeCapable (moment) {
             return moment.tz(value, timezone || 'UTC')
           }
         }
-      }
-    },
-    methods: {
+      },
+
       /**
-       * Create moment object in local timezone.
+       * Function for creating moment object in local timezone.
        *
-       * @param {moment|string|Date} value Datetime value that can be accepted by moment.
+       * @since [*next-version*]
        *
-       * @return {moment}
+       * @param {CreateLocalDatetimeFunction} createLocalDatetime
        */
-      createLocalDatetime (value = null) {
-        if (!value) {
-          value = moment()
+      createLocalDatetime: {
+        default () {
+          return  (value = null) => {
+            if (!value) {
+              value = moment()
+            }
+            return this.createDatetime(value, this.timezone)
+          }
         }
-        return this.createDatetime(value, this.timezone)
       },
     }
   }

--- a/src/typedefs.js
+++ b/src/typedefs.js
@@ -36,3 +36,20 @@
  * @param {string|Date} value Any value that should be used for creating date.
  * @param {string} timezone Timezone in which date should be created
  */
+
+/**
+ * Function for creating datetime in local timezone.
+ *
+ * @function CreateLocalDatetimeFunction
+ *
+ * @param {string|Date} value Any value that should be used for creating date.
+ */
+
+/**
+ * Provide ability to create datetime objects.
+ *
+ * @class CreateDatetimeCapable
+ *
+ * @method {CreateDatetimeFunction} createDatetime
+ * @method {CreateLocalDatetimeFunction} createLocalDatetime
+ */

--- a/src/typedefs.js
+++ b/src/typedefs.js
@@ -27,3 +27,12 @@
  * @param {string} start Range start datetime in ISO8601.
  * @param {string} end Range end datetime in ISO8601
  */
+
+/**
+ * Function for creating datetime in some timezone.
+ *
+ * @function CreateDatetimeFunction
+ *
+ * @param {string|Date} value Any value that should be used for creating date.
+ * @param {string} timezone Timezone in which date should be created
+ */


### PR DESCRIPTION
Helps to close https://github.com/RebelCode/bookings-js/issues/54

### How it works
The main principle behind this solution is "when timezone is set, use that timezone to create times". As result, all datetimes in displayed correctly in selected timezone, or in the local time, if timezone is not selected.